### PR TITLE
Add github actions

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,0 +1,15 @@
+name: Audit
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install audit
+      run: cargo install cargo-audit
+    - name: Run audit
+      run: cargo audit

--- a/.github/workflows/clippy.yaml
+++ b/.github/workflows/clippy.yaml
@@ -1,0 +1,18 @@
+on: [push]
+
+name: Clippy
+jobs:
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,15 @@
+name: Rust
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/.github/workflows/rustfmt.yaml
+++ b/.github/workflows/rustfmt.yaml
@@ -1,0 +1,15 @@
+name: Rustfmt
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install rustfmt
+      run: rustup component add rustfmt
+    - name: Check style
+      run: cargo fmt --all -- --check

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# ethereum-forkid
+
+![Rust](https://github.com/vorot93/ethereum-forkid/workflows/Rust/badge.svg)
+![Clippy](https://github.com/vorot93/ethereum-forkid/workflows/Clippy/badge.svg)
+![Audit](https://github.com/vorot93/ethereum-forkid/workflows/Audit/badge.svg)
+![Rustfmt](https://github.com/vorot93/ethereum-forkid/workflows/Rustfmt/badge.svg)


### PR DESCRIPTION
Adding some checks:

- `rust` just compiles and runs the tests
- `audit` to check if dependencies are safe
- `clippy` do not allow commits if clippy generates warnings
- `coverage`, runs coverage tests and reports for commit deltas. Note that is required to get the authorization `CODECOV_TOKEN` token from codecov.io. Please, note that the configuration file `./codecov.yml` is used with relaxed coverage deltas to allow painless refactors. RUSTFLAGS are quite weird but are the recommended ones to run the coverage.
- `rustfmt` does not allow commits if code has not been properly formatted
